### PR TITLE
Dynamic request rate based on % of matches available.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"time"
 
@@ -48,8 +47,6 @@ func Setup() {
 		}{}
 
 		json.Unmarshal(raw, &specified)
-
-		fmt.Println(specified)
 
 		// Replace timeout if its present (parse first!)
 		if specified.HTTPTimeout != "" {

--- a/grab.go
+++ b/grab.go
@@ -69,7 +69,7 @@ func main() {
 		}
 		ksLock.Unlock()
 
-		ui.UpdateQueuedSummoners(summoners.Filled())
+		ui.UpdateQueuedSummoners(summoners.Filled() * 100)
 		ui.UpdateTotalSummoners(len(knownSummoners))
 	})
 	// Shuffle so we don't start with the same group every time.
@@ -120,8 +120,10 @@ func requestLoop() {
 		}
 	}()
 
+	// Seed the RNG
+	rand.Seed(time.Now().Unix())
 	pace.Run(func() {
-		if rand.Float32() > 0.1 && matches.Available() { // Request match
+		if rand.Float32() < matches.Filled() { // Request match
 			getMatch()
 			requestLog <- time.Now()
 		} else if summoners.Available() { // Request summoner games
@@ -162,7 +164,7 @@ func getMatch() {
 		}
 		ksLock.Unlock()
 
-		ui.UpdateQueuedSummoners(summoners.Filled())
+		ui.UpdateQueuedSummoners(summoners.Filled() * 100)
 		ui.UpdateTotalSummoners(len(knownSummoners))
 	})
 }
@@ -202,7 +204,7 @@ func getSummoner() {
 			}
 		}
 
-		ui.UpdateQueuedMatches(matches.Filled())
+		ui.UpdateQueuedMatches(matches.Filled() * 100)
 		ui.UpdateTotalMatches(store.Count())
 	})
 

--- a/structs/matchlist.go
+++ b/structs/matchlist.go
@@ -77,7 +77,7 @@ func (ml *IDList) Available() bool {
 
 // Filled : Returns the percentage of the list capacity that's filled
 func (ml *IDList) Filled() float32 {
-	return (float32(len(ml.Queue)) / float32(MaxIDListSize)) * 100
+	return (float32(len(ml.Queue)) / float32(MaxIDListSize))
 }
 
 func (ml *IDList) Shuffle() {


### PR DESCRIPTION
Scaling is now based on the % of matches that are available vs queue size. As more matches are available, more will be requested. This means that the queue should be much more productive after the queue has filled but still handle empty- and low-count situations correctly.