### PR TITLE
Continuous integration (#23)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 config.json
+vendor/github.com

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,25 @@
+builds:
+  - main: grab.go
+    binary: grab
+    goos:
+      - windows
+      - darwin
+      - linux
+    goarch:
+      - amd64
+# Archive customization
+archive:
+  format: tar.gz
+
+  # Customize the name of the packages.
+  replacements:
+    amd64: 64-bit
+    darwin: macOS
+
+  # Everything gets .tar.gz except for Windows.
+  format_overrides:
+    - goos: windows
+      format: zip
+
+  files:
+    - LICENSE.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,6 @@ before_install:
 
 script:
   - goveralls -service=travis-ci
+
+after_success:
+  - test -n "$TRAVIS_TAG" && curl -sL https://git.io/goreleaser | bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: go
 
 go:
+  - master
   - 1.8
   - 1.7
   - 1.6
-  - master
 
-install:
+before_install:
   - go get -u github.com/kardianos/govendor
   - go get github.com/mattn/goveralls
   - govendor sync

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ go:
 
 install:
   - go get -u github.com/kardianos/govendor
-  - govendor update +v
+  - govendor sync

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+
+go:
+  - 1.8
+  - 1.7
+  - 1.6
+  - master
+
+install:
+  - go get -u github.com/kardianos/govendor
+  - govendor update +v

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,8 @@ go:
 
 install:
   - go get -u github.com/kardianos/govendor
+  - go get github.com/mattn/goveralls
   - govendor sync
+
+script:
+  - goveralls -service=travis-ci

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,7 @@
+Copyright 2017 Luke Segars
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Matchgrab: League of Legends match importer
 
+[![Build Status](https://travis-ci.org/anyweez/matchgrab.svg?branch=master)](https://travis-ci.org/anyweez/matchgrab)
+[![Coverage Status](https://coveralls.io/repos/github/anyweez/matchgrab/badge.svg)](https://coveralls.io/github/anyweez/matchgrab)
+
 Matchgrab retrieves League of Legends match data from [Riot's API](https://developer.riotgames.com). It starts with a seed user, starts downloading match data for that user, and then performs the same process for other summoners who played in the downloaded matches. It continues this process until you stop it.
 
-You must have an [API key issued by Riot](https://developer.riotgames.com/) in order to use this tool, and you will only be able to download data at the rates that Riot allows. 
+You must have an [API key issued by Riot](https://developer.riotgames.com/) in order to use this tool, and you will only be able to download data at the rates that Riot allows.
 
 ## Collecting data
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,7 +3,7 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "Bjl8V249BSzIN/LuyybVPRsvsHE=",
+			"checksumSHA1": "En911lu7f/u83ScLGxAaTM2SJVE=",
 			"path": "github.com/gizak/termui",
 			"revision": "72304ddb9b4e9838426a021aad64a5a860e98324",
 			"revisionTime": "2017-05-02T14:12:00Z"


### PR DESCRIPTION
Adds continuous integration via Travis that builds, runs tests, generates code coverage #'s, and (on tag commits) automatically builds new releases and pushes them to github.

Code coverage numbers are still low (~10%) but I'll take care of that in a separate PR. My main goal now is to have consistent instrumentation as well as releases to make this more accessible.