### PR TITLE
Replaced map[RiotID]bool with bloom filter (#15).

### DIFF
--- a/structs/matchlist.go
+++ b/structs/matchlist.go
@@ -1,46 +1,56 @@
 package structs
 
 import (
+	"fmt"
+	"log"
 	"math/rand"
 	"sync"
 	"time"
+
+	"github.com/willf/bloom"
 )
 
-const MaxIDListSize = 100000
+const (
+	MaxIDListSize = 100000
+	BloomGrowBy   = 2     // double in size on each grow()
+	BloomFpRate   = 0.001 // Increasing means more duplicate requests, decreasing means bloom filter consumes more memory.
+)
 
+// IDList : A queue-like data structure that only allows items to be added once; if an item
+// has already been added then attempts to re-add it will be rejected. IDLists are safe to
+// use concurrently.
 type IDList struct {
 	Queue chan RiotID
-	// Overflow []RiotID
-	ids map[RiotID]bool
 
-	// Number of available values
-	// count int
-	// Number of recorded or queued values
-	// known int
+	blacklist   *bloom.BloomFilter
+	blcap       uint       // Maximum amount of records blacklist can hold
+	blacklisted uint       // Total number of values that have been blacklisted
+	lockIDs     sync.Mutex // Concurrency mutexes
 
-	// Concurrency mutexes
-	lockIDs sync.Mutex
-	// lockOverflow sync.Mutex
+	_growCount int // [debugging] count number of grow() calls
 }
 
+// NewIDList : Create an empty IDList.
 func NewIDList() *IDList {
+	blsize := uint(MaxIDListSize * 10)
+
 	ml := IDList{
-		Queue: make(chan RiotID, MaxIDListSize),
-		// Overflow: make([]RiotID, 0, MaxIDListSize),
-		ids: make(map[RiotID]bool),
-		// count: 0,
-		// known: 0,
+		Queue:       make(chan RiotID, MaxIDListSize),
+		blacklisted: 0,
+		blacklist:   bloom.NewWithEstimates(blsize, BloomFpRate),
+		blcap:       blsize,
 	}
 
 	return &ml
 }
 
+// Add : Add a new item to the list if it hasn't been added before. Items are
+// added in order and cannot be added to the same list twice.
+// Note that `IDList` uses a bloom filter to track which elements have been
+// added and some false positives occur, meaning that some items will be
+// incorrectly blocked.
 func (ml *IDList) Add(m RiotID) bool {
-	ml.lockIDs.Lock()
-	_, exists := ml.ids[m]
-	ml.lockIDs.Unlock()
-
-	if !exists {
+	if !ml.Blacklisted(m) {
 		// Try to add it to the queue; if it doesn't work then skip
 		select {
 		case ml.Queue <- m:
@@ -55,13 +65,54 @@ func (ml *IDList) Add(m RiotID) bool {
 	return false
 }
 
-func (ml *IDList) Blacklist(m RiotID) {
-	ml.lockIDs.Lock()
-	ml.ids[m] = true
-	// ml.known++
-	ml.lockIDs.Unlock()
+// Blacklisted : Returns a boolean indicating whether the specified ID exists in
+// the list. Note that `IDList` uses a bloom filter to track which elements have
+// been added so some false positives will occur.
+func (ml *IDList) Blacklisted(m RiotID) bool {
+	return ml.blacklist.Test(m.Bytes())
 }
 
+// Blacklist : Add a new item to the blacklist. This is automatically called by
+// Add() and shouldn't be called externally unless you want to blacklist *without*
+// adding to the list.
+func (ml *IDList) Blacklist(m RiotID) {
+	// Check to make sure it isn't blacklisted (primarily to keep the
+	// count accurate).
+	if !ml.Blacklisted(m) {
+		ml.lockIDs.Lock()
+
+		// Grow before we add if we're at capacity
+		if ml.blacklisted >= ml.blcap {
+			ml.grow() // MUST hold lockIDs lock
+		}
+
+		// Add byte buffer to blacklist.
+		ml.blacklist.Add(m.Bytes())
+
+		ml.blacklisted++
+		ml.lockIDs.Unlock()
+	}
+}
+
+// grow : Increase the capacity of the bloom filter.
+func (ml *IDList) grow() {
+	log.Println(fmt.Sprintf("growing @ %s", time.Now()))
+	// Old blacklist; outgrown
+	retired := ml.blacklist
+
+	// Replace with a new blacklist struct that's bigger
+	ml.blcap = ml.blcap * BloomGrowBy
+	ml.blacklist = bloom.NewWithEstimates(ml.blcap, BloomFpRate)
+
+	// Merge in old data so that we don't lose any data.
+	// Side note: figure out how this works.
+	ml.blacklist.Merge(retired)
+
+	ml._growCount++
+}
+
+// Next : Get the next item from the list if anything is available. The second
+// return value will be true whenever an actual value is returned and false otherwise.
 func (ml *IDList) Next() (RiotID, bool) {
 	if len(ml.Queue) > 0 {
 		return <-ml.Queue, true
@@ -80,6 +131,9 @@ func (ml *IDList) Filled() float32 {
 	return (float32(len(ml.Queue)) / float32(MaxIDListSize))
 }
 
+// Shuffle : Randomly distributes all items currently in the queue. Note that
+// this only applies to items *currently in the queue* and will not affect
+// insertion order for new items.
 func (ml *IDList) Shuffle() {
 	rand.Seed(time.Now().UnixNano())
 
@@ -102,8 +156,3 @@ func (ml *IDList) Shuffle() {
 		ml.Queue <- ids[i]
 	}
 }
-
-// Known : Return the number of ID's that have ever been blacklisted on this list.
-// func (ml *IDList) Known() int {
-// 	return ml.known
-// }

--- a/structs/matchlist_test.go
+++ b/structs/matchlist_test.go
@@ -1,0 +1,92 @@
+package structs
+
+import (
+	"fmt"
+	"testing"
+)
+
+// Registers an error and prints the `msg` if `cond` is false.
+func failIf(cond bool, t *testing.T, msg string) {
+	if cond {
+		t.Error(msg)
+	}
+}
+
+// Test that adding and retrieving numbers works.
+func TestBasicAdd(t *testing.T) {
+	idl := NewIDList()
+
+	idl.Add(12345)
+	id, real := idl.Next()
+
+	failIf(id != 12345, t, "got unadded value back")
+	failIf(!real, t, "got unexpected item back")
+}
+
+// Ensure we get numbers back in the same order we added them.
+func TestRetrievalOrder(t *testing.T) {
+	idl := NewIDList()
+
+	var i RiotID
+	for i = 0; i < 100; i++ {
+		idl.Add(i)
+	}
+
+	for i = 0; i < 100; i++ {
+		id, real := idl.Next()
+
+		failIf(id != i, t, "got incorrect item back")
+		failIf(!real, t, "queue was empty (?)")
+	}
+
+	failIf(idl.Available(), t, "items still available (bad)")
+}
+
+// Confirm that the right number of elements have been blacklisted.
+func TestBlacklistCount(t *testing.T) {
+	idl := NewIDList()
+	addedCount := uint(0)
+
+	for i := 0; i < 100; i++ {
+		if idl.Add(RiotID(i)) {
+			addedCount++
+		}
+
+		failIf(idl.blacklisted != addedCount, t, "some elements not added to list")
+	}
+}
+
+// Ensure that grow() is triggered automatically and the correct number
+// of times when blcap is exceeded. Also make sure the correct number of values
+// are blacklisted despite the grow().
+func TestGrowTrigger(t *testing.T) {
+	idl := NewIDList()
+	overflow := idl.blcap + 100
+	addCount := uint(0)
+
+	curr := 0
+	for addCount < overflow {
+		if idl.Add(RiotID(curr)) { // add
+			addCount++
+			idl.Next() // immediately remove
+		}
+
+		curr++
+	}
+
+	failIf(idl._growCount != 1, t, fmt.Sprintf("_growCount = %d", idl._growCount))
+	failIf(idl.blacklisted != addCount, t, "incorrect blacklist count")
+}
+
+// Ensure that grow() operations are non-destructive and keep track of
+// values from the smaller blacklist.
+func TestGrowMerge(t *testing.T) {
+	idl := NewIDList()
+
+	for i := 0; i < int(idl.blcap)+10; i++ {
+		idl.Add(RiotID(12345))
+
+		// Should always be exactly 1; key edge case is after grow operation.
+		failIf(idl.blacklisted != 1, t, "incorrect number of items blacklisted")
+	}
+}


### PR DESCRIPTION
Working on testing with larger datasets but should be much more memory efficient now. The
downside is that we'll now get some false positives (currently set semi-arbitrarily to .1%)
but that may need to be tweaked.

Testing memory use under load; will add that to issue #15.